### PR TITLE
Feature - history saves the entire contents of the thread (#72)

### DIFF
--- a/explore-assistant-examples/samples.json
+++ b/explore-assistant-examples/samples.json
@@ -1,17 +1,14 @@
 [
     {
       "category": "Cohorting",
-      "prompt": "Count of Users by first purchase date",
-      "color": "green"
+      "prompt": "Count of Users by first purchase date"
     },
     {
       "category": "Audience Building",
-      "prompt":"Users who have purchased more than 100 dollars worth of Calvin Klein products and have purchased in the last 30 days",
-      "color": "blue"
+      "prompt":"Users who have purchased more than 100 dollars worth of Calvin Klein products and have purchased in the last 30 days"
     },
     {
       "category": "Period Comparison",
-      "prompt": "Total revenue by category this year compared to last year in a line chart with year pivoted",
-      "color": "red"
+      "prompt": "Total revenue by category this year compared to last year in a line chart with year pivoted"
     }
 ]

--- a/explore-assistant-extension/.env_example
+++ b/explore-assistant-extension/.env_example
@@ -1,6 +1,3 @@
-LOOKER_MODEL=<This is your Looker model name>
-LOOKER_EXPLORE=<This is your Looker explore name>
-
 VERTEX_AI_ENDPOINT=<This is your Deployed Cloud Function Endpoint>
 VERTEX_CF_AUTH_TOKEN=<This is the token used to communicate with the cloud function>
 

--- a/explore-assistant-extension/README.md
+++ b/explore-assistant-extension/README.md
@@ -73,8 +73,6 @@ jsonPayload.component="explore-assistant-metadata"
    Regardless of the backend, you're going to need:
 
    ```
-   LOOKER_MODEL=<This is your Looker model name>
-   LOOKER_EXPLORE=<This is your Looker explore name>
    VERTEX_BIGQUERY_LOOKER_CONNECTION_NAME=<This is the connection name in Looker with the BQ project that has access to the remote connection and model>
    BIGQUERY_EXAMPLE_PROMPTS_CONNECTION_NAME=<The BQ connection name in Looker that has query access to example prompts. This may be the same as the Vertex Connection Name if using just one gcp project>
    BIGQUERY_EXAMPLE_PROMPTS_DATASET_NAME=<This is the dataset and project that contain the Example prompt data, assuming that differs from the Looker connection>

--- a/explore-assistant-extension/package-lock.json
+++ b/explore-assistant-extension/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
+        "@headlessui/react": "^1.7.19",
         "@looker/components": "^4.1.3",
         "@looker/components-providers": "1.5.31",
         "@looker/embed-sdk": "^1.6.1",
@@ -24,6 +25,7 @@
         "@reduxjs/toolkit": "^2.2.2",
         "@types/crypto-js": "^4.2.2",
         "@types/react": "^17.0.80",
+        "@types/uuid": "^10.0.0",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
         "highlight.js": "^11.9.0",
@@ -42,7 +44,8 @@
         "sass": "^1.72.0",
         "sass-loader": "^14.1.1",
         "styled-components": "^5.3.11",
-        "tailwindcss": "^3.4.7"
+        "tailwindcss": "^3.4.7",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.0",
@@ -2325,6 +2328,23 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.19",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
+      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -3255,12 +3275,6 @@
         }
       }
     },
-    "node_modules/@reduxjs/toolkit/node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
     "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -3459,6 +3473,33 @@
       "dependencies": {
         "@styled-system/core": "^5.1.2",
         "@styled-system/css": "^5.1.5"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.9.0.tgz",
+      "integrity": "sha512-5TeTSQBMV1PIFzBP9cduIX5klRaTvbOw+CxRx3LaUhwqiZLEZBZqz8anEIqG4eHNhDAe+BLarRDeNE9cNM1/EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.9.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.9.0.tgz",
+      "integrity": "sha512-Saga7/QRGej/IDCVP5BgJ1oDqlDT2d9rQyoflS3fgMS8ntJ8JGw/LBqK2GorHa06+VrNFc0tGz65XQHJQJetFQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/body-parser": {
@@ -3786,6 +3827,12 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -3868,6 +3915,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -4977,6 +5025,12 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -11450,14 +11504,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",
@@ -12968,13 +13018,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/explore-assistant-extension/package.json
+++ b/explore-assistant-extension/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
+    "@headlessui/react": "^1.7.19",
     "@looker/components": "^4.1.3",
     "@looker/components-providers": "1.5.31",
     "@looker/embed-sdk": "^1.6.1",
@@ -32,6 +33,7 @@
     "@reduxjs/toolkit": "^2.2.2",
     "@types/crypto-js": "^4.2.2",
     "@types/react": "^17.0.80",
+    "@types/uuid": "^10.0.0",
     "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",
     "highlight.js": "^11.9.0",
@@ -50,7 +52,8 @@
     "sass": "^1.72.0",
     "sass-loader": "^14.1.1",
     "styled-components": "^5.3.11",
-    "tailwindcss": "^3.4.7"
+    "tailwindcss": "^3.4.7",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/explore-assistant-extension/src/App.tsx
+++ b/explore-assistant-extension/src/App.tsx
@@ -1,34 +1,12 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { hot } from 'react-hot-loader/root'
 import { Route, Switch, Redirect } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
-import {
-  setExploreId,
-  setExploreName,
-  setModelName,
-} from './slices/assistantSlice'
-import { RootState } from './store'
 import { useLookerFields } from './hooks/useLookerFields'
 import { useBigQueryExamples } from './hooks/useBigQueryExamples'
 import AgentPage from './pages/AgentPage'
 
 const ExploreApp = () => {
-  const dispatch = useDispatch()
-  const {
-    exploreName,
-    modelName,
-    exploreId,
-  } = useSelector((state: RootState) => state.assistant)
-  const LOOKER_EXPLORE_ID =
-    exploreId || `${process.env.LOOKER_MODEL}/${process.env.LOOKER_EXPLORE}` || ''
-  useEffect(() => {
-    dispatch(setExploreId(LOOKER_EXPLORE_ID))
-    dispatch(setModelName(modelName || process.env.LOOKER_MODEL || ''))
-    dispatch(setExploreName(exploreName || process.env.LOOKER_EXPLORE || ''))
-  }, [])
-
-
-  // load dimensions and measures into the state
+  // load dimensions, measures and examples into the state
   useLookerFields()
   useBigQueryExamples()
 

--- a/explore-assistant-extension/src/components/Chat/ExploreMessage.tsx
+++ b/explore-assistant-extension/src/components/Chat/ExploreMessage.tsx
@@ -1,27 +1,26 @@
 import React from 'react'
 
 import Message from './Message'
-import { Link } from '@looker/components'
 import { useContext } from 'react'
 import { ExtensionContext } from '@looker/extension-sdk-react'
-import { useDispatch, useSelector } from 'react-redux'
-import { RootState } from '../../store'
+import { useDispatch } from 'react-redux'
 import {
   openSidePanel,
   setSidePanelExploreUrl,
 } from '../../slices/assistantSlice'
-import { Explore, OpenInNew, Share } from '@material-ui/icons'
+import { OpenInNew } from '@material-ui/icons'
 
 interface ExploreMessageProps {
+  exploreId: string
+  modelName: string
   prompt: string
   queryArgs: string
 }
 
-const ExploreMessage = ({ prompt, queryArgs }: ExploreMessageProps) => {
+const ExploreMessage = ({ modelName, exploreId, prompt, queryArgs }: ExploreMessageProps) => {
   const dispatch = useDispatch()
-  const { exploreId } = useSelector((state: RootState) => state.assistant)
   const { extensionSDK } = useContext(ExtensionContext)
-  const exploreHref = `/explore/${exploreId}?${queryArgs}`
+  const exploreHref = `/explore/${modelName}/${exploreId}?${queryArgs}`
   const openExplore = () => {
     extensionSDK.openBrowserWindow(exploreHref, '_blank')
   }

--- a/explore-assistant-extension/src/components/Chat/SummaryMessage.tsx
+++ b/explore-assistant-extension/src/components/Chat/SummaryMessage.tsx
@@ -3,30 +3,55 @@ import React, { useEffect } from 'react'
 import Message from './Message'
 import useSendVertexMessage from '../../hooks/useSendVertexMessage'
 import MarkdownText from './MarkdownText'
+import { useDispatch } from 'react-redux'
+import {
+  SummarizeMesage,
+  updateLastHistoryEntry,
+  updateSummaryMessage,
+} from '../../slices/assistantSlice'
 
 interface SummaryMessageProps {
-  queryArgs: string
+  message: SummarizeMesage
 }
 
-const SummaryMessage = ({ queryArgs }: SummaryMessageProps) => {
+const SummaryMessage = ({ message }: SummaryMessageProps) => {
+  const queryArgs = message.exploreUrl
+
+  const dispatch = useDispatch()
   const [loading, setLoading] = React.useState<boolean>(true)
   const [summary, setSummary] = React.useState<string>('')
 
   const { summarizeExplore } = useSendVertexMessage()
 
   useEffect(() => {
+    if (message.summary) {
+      setSummary(message.summary)
+      setLoading(false)
+      return
+    }
+
     const fetchSummary = async () => {
       const response = await summarizeExplore(queryArgs)
       if (!response) {
         setSummary('There was an error summarizing the data')
       } else {
         setSummary(response)
+
+        // save to the store
+        dispatch(
+          updateSummaryMessage({ uuid: message.uuid, summary: response }),
+        )
+
+        // update the history with the current contents of the thread
+        dispatch(updateLastHistoryEntry())
       }
+
       setLoading(false)
     }
+
     fetchSummary()
-  }, [])
-  console.log(summary)
+  }, [message])
+
   return (
     <Message actor="system" createdAt={Date.now()}>
       <Section my={'u2'}>
@@ -35,9 +60,9 @@ const SummaryMessage = ({ queryArgs }: SummaryMessageProps) => {
           <Spinner size={20} my={'u2'} />
         ) : (
           <>
-            <div className="">
+            <div className="text-sm mt-6">
               <MarkdownText text={summary} />
-          </div>
+            </div>
           </>
         )}
       </Section>

--- a/explore-assistant-extension/src/components/ExploreEmbed.tsx
+++ b/explore-assistant-extension/src/components/ExploreEmbed.tsx
@@ -28,18 +28,21 @@ import React, { useContext, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import { LookerEmbedSDK } from '@looker/embed-sdk'
 import { ExtensionContext } from '@looker/extension-sdk-react'
-import { useSelector } from 'react-redux'
-import { RootState } from '../store'
 
 export interface ExploreEmbedProps {
-  exploreUrl: string
+  modelName: string | null | undefined
+  exploreId: string | null | undefined
+  exploreUrl: string | null | undefined
 }
 
-export const ExploreEmbed = ({ exploreUrl }: ExploreEmbedProps) => {
+export const ExploreEmbed = ({ modelName, exploreId, exploreUrl }: ExploreEmbedProps) => {
+
+  if(!modelName || !exploreId || !exploreUrl) {
+    return <></>
+  }
+
   const { extensionSDK } = useContext(ExtensionContext)
   const [exploreRunStart, setExploreRunStart] = React.useState(false)
-
-  const { exploreId } = useSelector((state: RootState) => state.assistant)
 
   const canceller = (event: any) => {
     return { cancel: !event.modal }
@@ -82,7 +85,7 @@ export const ExploreEmbed = ({ exploreUrl }: ExploreEmbedProps) => {
       })
       el.innerHTML = ''
       LookerEmbedSDK.init(hostUrl)
-      LookerEmbedSDK.createExploreWithId(exploreId)
+      LookerEmbedSDK.createExploreWithId(modelName + '/' + exploreId)
         .appendTo(el)
         .withClassName('looker-embed')
         .withParams(paramsObj)

--- a/explore-assistant-extension/src/components/SamplePrompts.tsx
+++ b/explore-assistant-extension/src/components/SamplePrompts.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { resetChat, setIsChatMode, setQuery } from '../slices/assistantSlice'
+import {
+  AssistantState,
+  resetChat,
+  setIsChatMode,
+  setQuery,
+} from '../slices/assistantSlice'
 import { RootState } from '../store'
+
 
 const SamplePrompts = () => {
   const dispatch = useDispatch()
   const {
-    examples,
-    exploreId,
-  } = useSelector((state: RootState) => state.assistant)
-  const [samplesLoaded, setSamplesLoaded] = React.useState(false)
+    currentExplore: { modelName, exploreId },
+    examples: { exploreSamples },
+  } = useSelector((state: RootState) => state.assistant as AssistantState)
 
-  React.useEffect(() => {
-    if(examples.exploreSamples.length > 0) {
-      setSamplesLoaded(true)
-      console.log(examples.exploreSamples)
-    }
-  },[examples.exploreSamples])
+  const samples = exploreSamples[`${modelName}:${exploreId}`]
 
   const handleSubmit = (prompt: string) => {
     dispatch(resetChat())
@@ -24,35 +24,24 @@ const SamplePrompts = () => {
     dispatch(setIsChatMode(true))
   }
 
-  if(samplesLoaded) {
-    const categorizedPrompts = JSON.parse(
-      examples.exploreSamples.filter(
-        explore => explore.explore_id === exploreId.replace("/",":")
-      )
-      ?.[0]
-      ?.['samples'] ?? '[]'
-    )
+  if(!samples) return <></>
 
-    return (
-      <div className="flex flex-wrap max-w-5xl">
-        {categorizedPrompts.map((item, index: number) => (
-              <div
-              className="flex flex-col w-56 bg-gray-200/50 hover:bg-gray-200 rounded-lg cursor-pointer text-sm p-4 m-2"
-              key={index}
-              onClick={() => {
-                handleSubmit(item.prompt)
-              }}
-              >
-                <div className="flex-grow font-light line-camp-5">{item.prompt}</div>
-                <div className="mt-2 font-semibold justify-end">{item.category}</div>
-              </div>
-            ))
-        }
-      </div>
-    )
-  } else {
-    return <></>
-  }
+  return (
+    <div className="flex flex-wrap max-w-5xl">
+      {samples.map((item, index: number) => (
+        <div
+          className="flex flex-col w-56 min-h-44 bg-gray-200/50 hover:bg-gray-200 rounded-lg cursor-pointer text-sm p-4 m-2"
+          key={index}
+          onClick={() => {
+            handleSubmit(item.prompt)
+          }}
+        >
+          <div className="flex-grow font-light line-camp-5">{item.prompt}</div>
+          <div className="mt-2 font-semibold justify-end">{item.category}</div>
+        </div>
+      ))}
+    </div>
+  )
 }
 
 export default SamplePrompts

--- a/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/MessageThread.tsx
@@ -5,30 +5,37 @@ import Message from '../../components/Chat/Message'
 import ExploreMessage from '../../components/Chat/ExploreMessage'
 import SummaryMessage from '../../components/Chat/SummaryMessage'
 import { CircularProgress } from '@material-ui/core'
+import { AssistantState, ChatMessage } from '../../slices/assistantSlice'
 
 const MessageThread = () => {
   const { currentExploreThread, isQuerying } = useSelector(
-    (state: RootState) => state.assistant,
+    (state: RootState) => state.assistant as AssistantState,
   )
 
-  const messages = currentExploreThread.messages
+  if(currentExploreThread === null) {
+    return <></>
+  }
+
+  const messages = currentExploreThread.messages as ChatMessage[]
   return (
     <div className="">
-      {messages.map((message, index) => {
+      {messages.map((message) => {
         if (message.type === 'explore') {
           return (
             <ExploreMessage
-              key={index}
+              key={message.uuid}
+              modelName={currentExploreThread.modelName}
+              exploreId={currentExploreThread.exploreId}
               queryArgs={message.exploreUrl}
               prompt={message.summarizedPrompt}
             />
           )
         } else if (message.type === 'summarize') {
-          return <SummaryMessage key={index} queryArgs={message.exploreUrl} />
+          return <SummaryMessage key={message.uuid} message={message} />
         } else {
           return (
             <Message
-              key={index}
+              key={message.uuid}
               message={message.message}
               actor={message.actor}
               createdAt={message.createdAt}

--- a/explore-assistant-extension/src/pages/AgentPage/Settings.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/Settings.tsx
@@ -1,20 +1,12 @@
 import React from 'react'
-import {
-  Modal,
-  Box,
-  Typography,
-  Switch,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemSecondaryAction,
-  MenuItem,
-  Select,
-  SelectChangeEvent
-} from '@mui/material'
+import { Modal, Box, Typography, Switch } from '@mui/material'
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '../../store'
-import { setSetting, setExploreName, setExploreId, setModelName, resetChat } from '../../slices/assistantSlice'
+import {
+  setSetting,
+  AssistantState,
+  resetExploreAssistant,
+} from '../../slices/assistantSlice'
 
 interface SettingsModalProps {
   open: boolean
@@ -23,17 +15,9 @@ interface SettingsModalProps {
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
   const dispatch = useDispatch()
-  const { settings, exploreId, explores } = useSelector(
-    (state: RootState) => state.assistant,
+  const { settings } = useSelector(
+    (state: RootState) => state.assistant as AssistantState,
   )
-
-  const setSelectedExplore = (e: SelectChangeEvent<any>) => {
-    const parsedExploreID = e.target.value.split(":")
-    dispatch(setExploreName(parsedExploreID[1]))
-    dispatch(setModelName(parsedExploreID[0]))
-    dispatch(setExploreId(e.target.value.replace(":","/")))
-    dispatch(resetChat())
-  }
 
   const handleToggle = (id: string) => {
     dispatch(
@@ -42,6 +26,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
         value: !settings[id].value,
       }),
     )
+  }
+
+  const handleReset = () => {
+    dispatch(resetExploreAssistant())
+    setInterval(() => {
+      window.location.reload()
+    }, 100)
   }
 
   if (!settings) return null
@@ -53,7 +44,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
       aria-labelledby="settings-modal-title"
       className="flex items-center justify-center"
     >
-      <Box className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+      <Box className="bg-white rounded-lg p-6 max-w-xl w-full mx-4">
         <Typography
           id="settings-modal-title"
           variant="h6"
@@ -62,45 +53,32 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
         >
           Settings
         </Typography>
-        <List>
+        <ul>
           {Object.entries(settings).map(([id, setting]) => (
-            <ListItem key={id + setting.name} className="py-2">
-              <ListItemText
-                primary={setting.name}
-                secondary={setting.description}
-                className="pr-4"
-              />
-              <ListItemSecondaryAction>
+            <li key={id} className="flex flex-row py-4">
+              <div className="flex-grow pr-4">
+                <div className="text-sm font-semibold">{setting.name}</div>
+                <div className="text-xs text-gray-500">
+                  {setting.description}
+                </div>
+              </div>
+              <div className="">
                 <Switch
-                edge="end"
-                onChange={() => handleToggle(id)}
-                checked={setting.value}
-                inputProps={{ 'aria-labelledby': `switch-${id}` }}
+                  edge="end"
+                  onChange={() => handleToggle(id)}
+                  checked={setting.value}
+                  inputProps={{ 'aria-labelledby': `switch-${id}` }}
                 />
-              </ListItemSecondaryAction>
-            </ListItem>
+              </div>
+            </li>
           ))}
-          <ListItem key={'explore-select'} className="py-2">
-            <ListItemText
-                primary={"Select your Explore"}
-                secondary={"Load a conversation with a different Explore. These explores are configured in the Backend deployment of Explore Assistant and are loaded dynamically from a table."}
-                className="pr-4"
-              />
-              <ListItemSecondaryAction>
-                <Select
-                  labelId="demo-simple-select-label"
-                  id="demo-simple-select"
-                  value={exploreId.replace("/",":")}
-                  label="Explore Select"
-                  onChange={setSelectedExplore}
-                >
-                  {explores.length > 0 && explores.map((explore, index) => (
-                    <MenuItem key={index} value={explore.explore_id}>{explore.explore_id.split(":")[1]}</MenuItem>
-                  ))}
-                </Select>
-              </ListItemSecondaryAction>
-          </ListItem>
-        </List>
+        </ul>
+        <div
+          onClick={handleReset}
+          className="flex justify-start text-xs text-blue-500 hover:text-blue-600 cursor-pointer hover:underline mt-4"
+        >
+          reset explore assistant
+        </div>
       </Box>
     </Modal>
   )

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import PromptInput from './PromptInput'
 import Sidebar from './Sidebar'
+import { v4 as uuidv4 } from 'uuid'
+
 import './style.css'
 import SamplePrompts from '../../components/SamplePrompts'
 import { ExploreEmbed } from '../../components/ExploreEmbed'
@@ -9,20 +11,42 @@ import { useDispatch, useSelector } from 'react-redux'
 import useSendVertexMessage from '../../hooks/useSendVertexMessage'
 import {
   addMessage,
-  addPrompt,
-  addToHistory,
+  AssistantState,
   closeSidePanel,
   openSidePanel,
+  setCurrenExplore,
   setIsQuerying,
   setQuery,
   setSidePanelExploreUrl,
-  setSidebarMessage,
+  updateCurrentThread,
   updateLastHistoryEntry,
 } from '../../slices/assistantSlice'
 import MessageThread from './MessageThread'
 import clsx from 'clsx'
 import { Close } from '@material-ui/icons'
-import { LinearProgress, Tooltip } from '@mui/material'
+import {
+  FormControl,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Tooltip,
+} from '@mui/material'
+import { getRelativeTimeString } from '../../utils/time'
+
+const toCamelCase = (input: string): string => {
+  // Remove underscores, make following letter uppercase
+  let result = input.replace(
+    /_([a-z])/g,
+    (_match, letter) => ' ' + letter.toUpperCase(),
+  )
+
+  // Capitalize the first letter of the string
+  result = result.charAt(0).toUpperCase() + result.slice(1)
+
+  return result
+}
 
 const AgentPage = () => {
   const endOfMessagesRef = useRef<HTMLDivElement>(null) // Ref for the last message
@@ -35,24 +59,62 @@ const AgentPage = () => {
     isChatMode,
     query,
     currentExploreThread,
+    currentExplore,
     sidePanel,
-    dimensions,
-    measures,
     examples,
-    exploreId,
-    bigQueryExamplesLoaded,
-    lookerFieldsLoaded
-  } = useSelector((state: RootState) => state.assistant)
+    semanticModels,
+    isBigQueryMetadataLoaded,
+    isSemanticModelLoaded,
+  } = useSelector((state: RootState) => state.assistant as AssistantState)
+
+  const explores = Object.keys(examples.exploreSamples).map((key) => {
+    const exploreParts = key.split(':')
+    return {
+      exploreKey: key,
+      modelName: exploreParts[0],
+      exploreId: exploreParts[1],
+    }
+  })
 
   const submitMessage = useCallback(async () => {
-    dispatch(setSidebarMessage(''))
-    dispatch(addPrompt(query))
+    if (query === '') {
+      return
+    }
+
     dispatch(setIsQuerying(true))
 
-    const promptList = [...currentExploreThread.promptList, query]
+    // update the prompt list
+    let promptList = [query]
+    if (currentExploreThread && currentExploreThread.promptList) {
+      promptList = [...currentExploreThread.promptList, query]
+    }
+
+    dispatch(
+      updateCurrentThread({
+        promptList,
+      }),
+    )
+
+    const exploreKey = currentExploreThread?.exploreKey || currentExplore.exploreKey
+
+    // set the explore if it is not set
+    if (!currentExploreThread?.modelName || !currentExploreThread?.exploreId) {
+      dispatch(
+        updateCurrentThread({
+          exploreId: currentExplore.exploreId,
+          modelName: currentExplore.modelName,
+          exploreKey: currentExplore.exploreKey,
+        }),
+      )
+    }
+
+    console.log('Prompt List: ', promptList)
+    console.log(currentExploreThread)
+    console.log(currentExplore)
 
     dispatch(
       addMessage({
+        uuid: uuidv4(),
         message: query,
         actor: 'user',
         createdAt: Date.now(),
@@ -70,26 +132,44 @@ const AgentPage = () => {
       return
     }
 
-    // update the history of the current thread and track explore id for update explore state when going back to prior conversations
-    if(currentExploreThread.messages.length > 0) {
-      // edit existing
-      dispatch(updateLastHistoryEntry({ message: promptSummary, exploreId: exploreId }))
-    } else {
-      // create new
-      dispatch(addToHistory({ message: promptSummary, exploreId: exploreId }))
-    }
-    
-    const newExploreUrl = await generateExploreUrl(promptSummary,dimensions, measures, examples.exploreGenerationExamples)
-    console.log("New Explore URL: ", newExploreUrl)
+    const { dimensions, measures } = semanticModels[exploreKey]
+    const exploreGenerationExamples =
+      examples.exploreGenerationExamples[exploreKey]
+
+    const newExploreUrl = await generateExploreUrl(
+      promptSummary,
+      dimensions,
+      measures,
+      exploreGenerationExamples,
+    )
+    console.log('New Explore URL: ', newExploreUrl)
     dispatch(setIsQuerying(false))
     dispatch(setQuery(''))
+
+    // If the newExploreUrl is empty, do not update the current thread
+    if (
+      newExploreUrl === '' ||
+      newExploreUrl === null ||
+      newExploreUrl === undefined
+    ) {
+      return
+    }
+
+    dispatch(
+      updateCurrentThread({
+        exploreUrl: newExploreUrl,
+        summarizedPrompt: promptSummary,
+      }),
+    )
 
     if (isSummary) {
       dispatch(
         addMessage({
+          uuid: uuidv4(),
           exploreUrl: newExploreUrl,
           actor: 'system',
           createdAt: Date.now(),
+          summary: '',
           type: 'summarize',
         }),
       )
@@ -99,6 +179,7 @@ const AgentPage = () => {
 
       dispatch(
         addMessage({
+          uuid: uuidv4(),
           exploreUrl: newExploreUrl,
           summarizedPrompt: promptSummary,
           actor: 'system',
@@ -107,31 +188,41 @@ const AgentPage = () => {
         }),
       )
     }
-  }, [generateExploreUrl, dispatch, query, dimensions, measures, examples])
 
-  const isDataLoaded = bigQueryExamplesLoaded && lookerFieldsLoaded
+    // update the history with the current contents of the thread
+    dispatch(updateLastHistoryEntry())
+  }, [query, semanticModels, examples, currentExplore, currentExploreThread])
+
+  const isDataLoaded = isBigQueryMetadataLoaded && isSemanticModelLoaded
 
   useEffect(() => {
     if (!query || query === '') {
       return
     }
 
-    if(query !== '' && isDataLoaded) {
+    if (query !== '' && isDataLoaded) {
       submitMessage()
       endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' })
     }
-
-  }, [query,isDataLoaded, submitMessage])
+  }, [query, isDataLoaded])
 
   const toggleDrawer = () => {
     setExpanded(!expanded)
   }
 
-  const isAgentReady =
-    dimensions.length > 0 &&
-    measures.length > 0 &&
-    examples.exploreGenerationExamples.length > 0 &&
-    examples.exploreRefinementExamples.length > 0
+  const handleExploreChange = (event: SelectChangeEvent) => {
+    const exploreKey = event.target.value
+    const [modelName, exploreId] = exploreKey.split(':')
+    dispatch(
+      setCurrenExplore({
+        modelName,
+        exploreId,
+        exploreKey,
+      }),
+    )
+  }
+
+  const isAgentReady = isBigQueryMetadataLoaded && isSemanticModelLoaded
 
   if (!isAgentReady) {
     return (
@@ -142,7 +233,9 @@ const AgentPage = () => {
               Hello.
             </span>
           </h1>
-          <h1 className="text-3xl text-gray-400">Getting everything ready...</h1>
+          <h1 className="text-3xl text-gray-400">
+            Getting everything ready...
+          </h1>
           <div className="max-w-2xl text-blue-300">
             <LinearProgress color="inherit" />
           </div>
@@ -161,8 +254,60 @@ const AgentPage = () => {
         } h-screen`}
       >
         <div className="flex-grow">
+          {isChatMode && (
+            <div className="z-10 flex flex-row items-start text-xs fixed inset w-full h-10 pl-2 bg-gray-50 border-b border-gray-200">
+              <ol
+                role="list"
+                className="flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-4"
+              >
+                <li className="flex">
+                  <div className="flex items-center">Explore Assistant</div>
+                </li>
+
+                <li className="flex">
+                  <div className="flex items-center h-10 ">
+                    <svg
+                      fill="currentColor"
+                      viewBox="0 0 44 44"
+                      preserveAspectRatio="none"
+                      aria-hidden="true"
+                      className="h-full w-6 flex-shrink-0 text-gray-300"
+                    >
+                      <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+                    </svg>
+                    <div className="ml-4 text-xs font-medium text-gray-500 hover:text-gray-700">
+                      {toCamelCase(currentExploreThread?.exploreId || '')}
+                    </div>
+                  </div>
+                </li>
+
+                <li className="flex">
+                  <div className="flex items-center h-10">
+                    <svg
+                      fill="currentColor"
+                      viewBox="0 0 44 44"
+                      preserveAspectRatio="none"
+                      aria-hidden="true"
+                      className="h-full w-6 flex-shrink-0 text-gray-300"
+                    >
+                      <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+                    </svg>
+                    <div className="ml-4 text-xs font-medium text-gray-500 hover:text-gray-700">
+                      Chat (started{' '}
+                      {getRelativeTimeString(
+                        currentExploreThread?.createdAt
+                          ? new Date(currentExploreThread.createdAt)
+                          : new Date(),
+                      )}
+                      )
+                    </div>
+                  </div>
+                </li>
+              </ol>
+            </div>
+          )}
           {isChatMode ? (
-            <div className="relative flex flex-row h-screen px-4 pt-4 ">
+            <div className="relative flex flex-row h-screen px-4 pt-6 ">
               <div
                 className={clsx(
                   'flex flex-col relative',
@@ -171,22 +316,25 @@ const AgentPage = () => {
               >
                 <div className="flex-grow overflow-y-auto max-h-full mb-36 ">
                   <div className="max-w-4xl mx-auto">
-                    {!isDataLoaded 
-                      ? (
-                        <div className="flex flex-col space-y-4 mx-auto max-w-2xl p-4">
-                          <h1 className="text-5xl font-bold">
-                            <span className="bg-clip-text text-transparent  bg-gradient-to-r from-pink-500 to-violet-500">
-                              Hello.
-                            </span>
-                          </h1>
-                          <h1 className="text-3xl text-gray-400">Loading the conversation and LookML Metadata... </h1>
-                          <div className="max-w-2xl text-blue-300">
-                            <LinearProgress color="inherit" />
-                          </div>
+                    {!isDataLoaded ? (
+                      <div className="flex flex-col space-y-4 mx-auto max-w-2xl p-4">
+                        <h1 className="text-5xl font-bold">
+                          <span className="bg-clip-text text-transparent  bg-gradient-to-r from-pink-500 to-violet-500">
+                            Hello.
+                          </span>
+                        </h1>
+                        <h1 className="text-3xl text-gray-400">
+                          Loading the conversation and LookML Metadata...{' '}
+                        </h1>
+                        <div className="max-w-2xl text-blue-300">
+                          <LinearProgress color="inherit" />
                         </div>
-                      )
-                      : <MessageThread />
-                    }
+                      </div>
+                    ) : (
+                      <div className="pt-8">
+                        <MessageThread />
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div
@@ -198,7 +346,7 @@ const AgentPage = () => {
 
               <div
                 className={clsx(
-                  'flex-grow flex flex-col pb-2 pl-2 transition-all duration-300 ease-in-out transform max-w-0',
+                  'flex-grow flex flex-col pb-2 pl-2 pt-8 transition-all duration-300 ease-in-out transform max-w-0',
                   sidePanel.isSidePanelOpen
                     ? 'max-w-full translate-x-0 opacity-100'
                     : 'translate-x-full opacity-0',
@@ -218,14 +366,18 @@ const AgentPage = () => {
                   </div>
                 </div>
                 <div className="bg-gray-200 border-l-2 border-r-2 border-gray-400 flex-grow">
-                  <ExploreEmbed exploreUrl={sidePanel.exploreUrl} />
+                  <ExploreEmbed
+                    modelName={currentExploreThread?.modelName}
+                    exploreId={currentExploreThread?.exploreId}
+                    exploreUrl={sidePanel.exploreUrl}
+                  />
                 </div>
                 <div className="bg-gray-400 text-white px-4 py-2 text-sm rounded-b-lg"></div>
               </div>
             </div>
           ) : (
             <>
-              <div className="flex flex-col space-y-4 mx-auto max-w-2xl p-4">
+              <div className="flex flex-col space-y-4 mx-auto max-w-3xl p-4">
                 <h1 className="text-5xl font-bold">
                   <span className="bg-clip-text text-transparent  bg-gradient-to-r from-pink-500 to-violet-500">
                     Hello.
@@ -236,7 +388,28 @@ const AgentPage = () => {
                 </h1>
               </div>
 
-              <div className="flex justify-center items-center mt-16">
+              <div className="flex flex-col max-w-3xl m-auto mt-16">
+                {explores.length > 1 && (
+                  <div className="text-md border-b-2 p-2 max-w-3xl">
+                    <FormControl className="">
+                      <InputLabel>Explore</InputLabel>
+                      <Select
+                        value={currentExplore.exploreKey}
+                        label="Explore"
+                        onChange={handleExploreChange}
+                      >
+                        {explores.map((oneExplore) => (
+                          <MenuItem
+                            key={oneExplore.exploreKey}
+                            value={oneExplore.exploreKey}
+                          >
+                            {toCamelCase(oneExplore.exploreId)}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </div>
+                )}
                 <SamplePrompts />
               </div>
 

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import process from 'process'
+import { v4 as uuidv4 } from 'uuid'
 
 export interface Setting {
   name: string
@@ -11,15 +11,22 @@ export interface Settings {
   [key: string]: Setting
 }
 
-export interface HistoryItem {
-  message: string
-  createdAt: number
-  exploreId: string
+export interface ExploreSamples {
+  [exploreKey: string]: Sample[]
 }
 
-interface HistoryItemPayload {
-  message: string
-  exploreId: string
+export interface ExploreExamples {
+  [exploreKey: string]: {
+    input: string
+    output: string
+  }[]
+}
+
+export interface RefinementExamples {
+  [exploreKey: string]: {
+    input: string[]
+    output: string
+  }[]
 }
 
 interface Field {
@@ -29,7 +36,13 @@ interface Field {
   tags: string[]
 }
 
-interface Message {
+interface Sample {
+  category: string
+  prompt: string
+}
+
+export interface Message {
+  uuid: string
   message: string
   actor: 'user' | 'system'
   createdAt: number
@@ -37,14 +50,8 @@ interface Message {
   intent?: 'exploreRefinement' | 'summarize' | 'dataQuestion'
 }
 
-interface Sample {
-  category: string
-  prompt: string
-  color: string
-}
-
-
-interface ExploreMessage {
+export interface ExploreMessage {
+  uuid: string
   exploreUrl: string
   actor: 'system'
   createdAt: number
@@ -52,83 +59,101 @@ interface ExploreMessage {
   summarizedPrompt: string
 }
 
-interface SummarizeMesage {
+export interface SummarizeMesage {
+  uuid: string
   exploreUrl: string
   actor: 'system'
   createdAt: number
   type: 'summarize'
+  summary: string
 }
 
-type ChatMessage = Message | ExploreMessage | SummarizeMesage
+export type ChatMessage = Message | ExploreMessage | SummarizeMesage
 
-type ExploreThread = {
+export type ExploreThread = {
+  uuid: string
+  exploreId: string
+  modelName: string
+  exploreKey: string
   messages: ChatMessage[]
   exploreUrl: string
   summarizedPrompt: string
   promptList: string[]
+  createdAt: number
+}
+
+
+export interface SemanticModel {
+  dimensions: Field[]
+  measures: Field[]
+  exploreKey: string
+  exploreId: string
+  modelName: string
 }
 
 export interface AssistantState {
   isQuerying: boolean
   isChatMode: boolean
-  currentExploreThread: ExploreThread
+  currentExploreThread: ExploreThread | null
+  currentExplore: {
+    exploreKey: string
+    modelName: string
+    exploreId: string
+  }
   sidePanel: {
     isSidePanelOpen: boolean
     exploreUrl: string
   }
-  history: HistoryItem[]
-  dimensions: Field[]
-  measures: Field[]
+  history: ExploreThread[]
+  semanticModels: {
+    [exploreKey: string]: SemanticModel
+  }
   query: string
-  exploreId: string
-  exploreName: string
-  modelName: string
-  explores: string[]
   examples: {
-    exploreGenerationExamples: {
-      input: string
-      output: string
-    }[]
-    exploreRefinementExamples: {
-      input: string[]
-      output: string
-    }[]
-    exploreSamples: {
-      explore_id: string
-      samples: string
-    }[]
+    exploreGenerationExamples: ExploreExamples
+    exploreRefinementExamples: RefinementExamples
+    exploreSamples: ExploreSamples
   },
   settings: Settings,
-  lookerFieldsLoaded: boolean,
-  bigQueryExamplesLoaded: boolean,
-  sidebarMessage: ''
+  isBigQueryMetadataLoaded: boolean,
+  isSemanticModelLoaded: boolean
+}
+
+export const newThreadState = () => {
+  const thread: ExploreThread = {    
+    uuid: uuidv4(),
+    exploreKey: '',
+    exploreId: '',
+    modelName: '',
+    messages: [],
+    exploreUrl: '',
+    summarizedPrompt: '',
+    promptList: [],
+    createdAt: Date.now()
+  }
+  return thread
 }
 
 export const initialState: AssistantState = {
   isQuerying: false,
   isChatMode: false,
-  currentExploreThread: {
-    messages: [],
-    exploreUrl: '',
-    summarizedPrompt: '',
-    promptList: [],
+  currentExploreThread: null,
+  currentExplore: {
+    exploreKey: '',
+    modelName: '',
+    exploreId: ''
   },
   sidePanel: {
     isSidePanelOpen: false,
     exploreUrl: '',
   },
   history: [],
-  dimensions: [],
-  measures: [],
   query: '',
-  exploreId: '',
-  exploreName: '',
-  modelName: '',
-  explores: [],
+  semanticModels: {},
   examples: {
-    exploreGenerationExamples: [],
-    exploreRefinementExamples: [],
-    exploreSamples: []
+    exploreGenerationExamples: {},
+    exploreRefinementExamples: {},
+    exploreSamples: {}
   },
   settings: {
     show_explore_data: {
@@ -137,15 +162,17 @@ export const initialState: AssistantState = {
       value: false,
     },
   },
-  lookerFieldsLoaded: false,
-  bigQueryExamplesLoaded: false,
-  sidebarMessage: ''
+  isBigQueryMetadataLoaded: false,
+  isSemanticModelLoaded: false
 }
 
 export const assistantSlice = createSlice({
   name: 'assistant',
   initialState,
   reducers: {
+    resetExploreAssistant: () => {
+      return initialState
+    },
     setIsQuerying: (state, action: PayloadAction<boolean>) => {
       state.isQuerying = action.payload
     },
@@ -154,18 +181,18 @@ export const assistantSlice = createSlice({
     },
     resetChatMode: (state) => {
       state.isChatMode = false
-      resetChat()
+      assistantSlice.caseReducers.resetChat(state)
     },
     resetSettings: (state) => {
       state.settings = initialState.settings
     },
     setSetting: (
       state,
-      action: PayloadAction<{ id: keyof Settings; value: boolean }>
+      action: PayloadAction<{ id: keyof Settings; value: boolean }>,
     ) => {
-      const { id, value } = action.payload;
+      const { id, value } = action.payload
       if (state.settings[id]) {
-        state.settings[id].value = value;
+        state.settings[id].value = value
       }
     },
     openSidePanel: (state) => {
@@ -177,62 +204,69 @@ export const assistantSlice = createSlice({
     setSidePanelExploreUrl: (state, action: PayloadAction<string>) => {
       state.sidePanel.exploreUrl = action.payload
     },
-    updateLastHistoryEntry: (state, action: PayloadAction<HistoryItemPayload>) => {
-      state.history[state.history.length - 1] = {
-        message: action.payload.message,
-        createdAt: Date.now(),
-        exploreId: action.payload.exploreId
-      }
-    },
-    addToHistory: (state, action: PayloadAction<HistoryItemPayload>) => {
-      state.history.push({
-        message: action.payload.message,
-        createdAt: Date.now(),
-        exploreId: action.payload.exploreId
-      })
-    },
-    setHistory: (state, action: PayloadAction<HistoryItem[]>) => {
-      state.history = action.payload
-    },
-    clearHistory: (state) => {
+    clearHistory : (state) => {
       state.history = []
     },
-    setDimensions: (state, action: PayloadAction<Field[]>) => {
-      state.dimensions = action.payload
+    updateLastHistoryEntry: (state) => {
+      if (state.currentExploreThread === null) {
+        return
+      }
+
+      if (state.history.length === 0) {
+        state.history.push({ ...state.currentExploreThread })
+      } else {
+        const currentUuid = state.currentExploreThread.uuid
+        const lastHistoryUuid = state.history[state.history.length - 1].uuid
+        if (currentUuid !== lastHistoryUuid) {
+          state.history.push({ ...state.currentExploreThread })
+        } else {
+          state.history[state.history.length - 1] = state.currentExploreThread
+        }
+      }
     },
-    setMeasures: (state, action: PayloadAction<Field[]>) => {
-      state.measures = action.payload
+    setSemanticModels: (state, action: PayloadAction<AssistantState['semanticModels']>) => {
+      state.semanticModels = action.payload
     },
     setExploreUrl: (state, action: PayloadAction<string>) => {
+      if (state.currentExploreThread === null) {
+        state.currentExploreThread = newThreadState()
+      }
       state.currentExploreThread.exploreUrl = action.payload
+    },
+    updateCurrentThread: (
+      state,
+      action: PayloadAction<Partial<ExploreThread>>,
+    ) => {
+      if (state.currentExploreThread === null) {
+        state.currentExploreThread = newThreadState()
+      }
+      state.currentExploreThread = {
+        ...state.currentExploreThread,
+        ...action.payload,
+      }
+    },
+    setCurrentThread: (state, action: PayloadAction<ExploreThread>) => {
+      state.currentExploreThread = { ...action.payload }
     },
     setQuery: (state, action: PayloadAction<string>) => {
       state.query = action.payload
     },
     resetChat: (state) => {
-      state.currentExploreThread = initialState.currentExploreThread
+      state.currentExploreThread = newThreadState()
+      state.currentExploreThread.uuid = uuidv4()
       state.query = ''
       state.isChatMode = false
       state.isQuerying = false
       state.sidePanel = initialState.sidePanel
     },
     addMessage: (state, action: PayloadAction<ChatMessage>) => {
+      if (state.currentExploreThread === null) {
+        state.currentExploreThread = newThreadState()
+      }
+      if (action.payload.uuid === undefined) {
+        action.payload.uuid = uuidv4()
+      }
       state.currentExploreThread.messages.push(action.payload)
-    },
-    addPrompt: (state, action: PayloadAction<string>) => {
-      state.currentExploreThread.promptList.push(action.payload)
-    },
-    setExploreId: (state, action: PayloadAction<string>) => {
-      state.exploreId = action.payload
-    },
-    setExploreName: (state, action: PayloadAction<string>) => {
-      state.exploreName = action.payload
-    },
-    setModelName: (state, action: PayloadAction<string>) => {
-      state.modelName = action.payload
-    },
-    setExplores: (state, action: PayloadAction<string[]>) => {
-      state.explores = action.payload
     },
     setExploreGenerationExamples(
       state,
@@ -246,27 +280,37 @@ export const assistantSlice = createSlice({
     ) {
       state.examples.exploreRefinementExamples = action.payload
     },
+    updateSummaryMessage: (
+      state,
+      action: PayloadAction<{ uuid: string; summary: string }>,
+    ) => {
+      const { uuid, summary } = action.payload
+      if (state.currentExploreThread === null) {
+        state.currentExploreThread = newThreadState()
+      }
+      const message = state.currentExploreThread.messages.find(
+        (message) => message.uuid === uuid,
+      ) as SummarizeMesage
+      message.summary = summary
+    },
     setExploreSamples(
       state,
-      action: PayloadAction<AssistantState['examples']['exploreSamples']>,
+      action: PayloadAction<ExploreSamples>,
     ) {
       state.examples.exploreSamples = action.payload
     },
-    setLookerFieldsLoaded: (
+    setisBigQueryMetadataLoaded: (
       state, 
       action: PayloadAction<boolean>
     ) => {
-      state.lookerFieldsLoaded = action.payload
+      state.isBigQueryMetadataLoaded = action.payload
     },
-    setBigQueryExamplesLoaded: (
-      state, 
-      action: PayloadAction<boolean>
-    ) => {
-      state.bigQueryExamplesLoaded = action.payload
+    setIsSemanticModelLoaded: (state, action: PayloadAction<boolean>) => {
+      state.isSemanticModelLoaded = action.payload
     },
-    setSidebarMessage: (state, action: PayloadAction<string>) => {
-      state.sidebarMessage = action.payload
-    },
+    setCurrenExplore: (state, action: PayloadAction<AssistantState['currentExplore']>) => {
+      state.currentExplore = action.payload
+    }
   },
 })
 
@@ -274,28 +318,24 @@ export const {
   setIsQuerying,
   setIsChatMode,
   resetChatMode,
-  addToHistory,
-  clearHistory,
+
   updateLastHistoryEntry,
-  addPrompt,
-  setHistory,
-  setDimensions,
-  setMeasures,
+  clearHistory,
+
+  setSemanticModels,
+  setIsSemanticModelLoaded,
   setExploreUrl,
   setQuery,
   resetChat,
   addMessage,
-  setExploreId,
-  setExploreName,
-  setModelName,
-  setExplores,
   setExploreGenerationExamples,
   setExploreRefinementExamples,
   setExploreSamples,
 
-  setBigQueryExamplesLoaded,
-  setLookerFieldsLoaded,
-  setSidebarMessage,
+  setisBigQueryMetadataLoaded,
+
+  updateCurrentThread,
+  setCurrentThread,
 
   openSidePanel,
   closeSidePanel,
@@ -303,6 +343,12 @@ export const {
 
   setSetting,
   resetSettings,
+
+  updateSummaryMessage,
+
+  setCurrenExplore,
+
+  resetExploreAssistant,
 } = assistantSlice.actions
 
 export default assistantSlice.reducer

--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -8,11 +8,13 @@ import assistantReducer, {
   Settings,
 } from './slices/assistantSlice'
 
+
 // Define keys that should never be persisted
 const neverPersistKeys: (keyof AssistantState)[] = [
-  'dimensions',
-  'measures',
+  'semanticModels',
   'examples',
+  'isBigQueryMetadataLoaded',
+  'isSemanticModelLoaded',
 ]
 
 // Create a transform function to filter out specific keys
@@ -57,9 +59,10 @@ const filterTransform = createTransform(
 )
 
 const persistConfig = {
-  key: 'root',
+  key: 'explore-assistant-state',
+  version: 1,
   storage,
-  whitelist: ['assistant'], // only assistant will be persisted
+  whitelist: ['assistant'],
   transforms: [filterTransform],
 }
 

--- a/explore-assistant-extension/src/utils/time.ts
+++ b/explore-assistant-extension/src/utils/time.ts
@@ -1,0 +1,67 @@
+export const getHumanReadableDuration = (startDateTime: string, endDateTime: string): string => {
+    const start = new Date(startDateTime)
+    const end = new Date(endDateTime)
+  
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      throw new Error('Invalid date-time string')
+    }
+  
+    const durationMilliseconds = end.getTime() - start.getTime()
+    let durationSeconds = Math.floor(durationMilliseconds / 1000)
+    const durationMinutes = Math.floor(durationSeconds / 60)
+    const durationHours = Math.floor(durationMinutes / 60)
+  
+    durationSeconds %= 60
+    const remainingMinutes = durationMinutes % 60
+  
+    const parts: string[] = []
+    if (durationHours > 0) {
+      parts.push(`${durationHours} ${durationHours === 1 ? 'hour' : 'hours'}`)
+    }
+    if (remainingMinutes > 0) {
+      parts.push(`${remainingMinutes} ${remainingMinutes === 1 ? 'minute' : 'minutes'}`)
+    }
+    if (durationSeconds > 0 || parts.length === 0) {
+      parts.push(`${durationSeconds} ${durationSeconds === 1 ? 'second' : 'seconds'}`)
+    }
+  
+    return parts.join(' ')
+  }
+  
+  export const getRelativeTimeString = (dateStr: string | Date) => {
+    const date = new Date(dateStr)
+    const now = new Date()
+  
+    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+    const diffInMinutes = Math.floor(diffInSeconds / 60)
+    const diffInHours = Math.floor(diffInMinutes / 60)
+    const diffInDays = Math.floor(diffInHours / 24)
+  
+    // Function to format the date as "Oct 25, 2023"
+    const formatDate = (date: Date) => {
+      const options: Intl.DateTimeFormatOptions = {
+        month: 'short', // allowed values: 'numeric', '2-digit', 'long', 'short', 'narrow'
+        day: 'numeric', // allowed values: 'numeric', '2-digit'
+        year: 'numeric', // allowed values: 'numeric', '2-digit'
+      }
+      return date.toLocaleDateString('en-US', options)
+    }
+  
+    let relativeTime
+  
+    if (diffInSeconds < 1) {
+      relativeTime = 'just now'
+    } else if (diffInSeconds < 60) {
+      relativeTime = diffInSeconds === 1 ? '1 second ago' : `${diffInSeconds} seconds ago`
+    } else if (diffInMinutes < 60) {
+      relativeTime = diffInMinutes === 1 ? '1 minute ago' : `${diffInMinutes} minutes ago`
+    } else if (diffInHours < 24) {
+      relativeTime = diffInHours === 1 ? '1 hour ago' : `${diffInHours} hours ago`
+    } else if (diffInDays <= 2) {
+      relativeTime = diffInDays === 1 ? '1 day ago' : `${diffInDays} days ago`
+    } else {
+      relativeTime = formatDate(date)
+    }
+  
+    return relativeTime
+  }


### PR DESCRIPTION
* update store to handle threads with uuids

* save the thread history

* lint fixes

* support multiple explores

* load all semantic models simultaneously

* use an exploreKey

* don't run the prefetches more than once

* use uuids for keys

* Add breadcrumb in the chat that shows explore

* color isn't used

* Use the correct explore key as you're switching between threads and explores

* remove un-used LOOKER_MODEL

* add a hard reset for the state